### PR TITLE
fix leftover // import ...

### DIFF
--- a/stream_test.go
+++ b/stream_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-package luigi // import "go.cryptoscope.co/luigi"
+package luigi
 
 import (
 	"context"


### PR DESCRIPTION
this was missing from 324065b9a7c66588b6a42896de8da1b8cff6668d